### PR TITLE
Allow disabling errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mlr3benchmark
 Title: Analysis and Visualisation of Benchmark Experiments
-Version: 0.1.3
+Version: 0.1.4
 Authors@R:
     c(person(given = "Sonabend",
            family = "Raphael",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# mlr3benchmark 0.1.4
+
+* Add `friedman_global` argument to posthoc tests and to autoplots to allow methods and plots to run even if the global Friedman test fails (i.e. don't reject null)
+
 # mlr3benchmark 0.1.3
 
 * Fix README

--- a/R/BenchmarkAggr.R
+++ b/R/BenchmarkAggr.R
@@ -298,7 +298,7 @@ BenchmarkAggr = R6Class("BenchmarkAggr",
     .dt = data.table(),
     .independent = logical(0),
     .crit_differences = function(meas = NULL, minimize = TRUE, p.value = 0.05, baseline = NULL, # nolint
-                                test = c("bd", "nemenyi"), friedman_posthoc = TRUE) {
+                                test = c("bd", "nemenyi"), friedman_global = TRUE) {
 
       meas = .check_meas(self, meas)
       test = match.arg(test)
@@ -325,7 +325,7 @@ BenchmarkAggr = R6Class("BenchmarkAggr",
       # Perform nemenyi test
       nem_test = tryCatch(self$friedman_posthoc(meas, p.value),
                  warning = function(w) {
-                   if (friedman_posthoc)
+                   if (friedman_global)
                      stopf("Global Friedman test non-significant (p > %s), try type = 'mean' instead.", p.value) # nolint
                    else
                      warning(sprintf("Global Friedman test non-significant (p > %s), try type = 'mean' instead.", p.value)) # nolint))

--- a/R/BenchmarkAggr.R
+++ b/R/BenchmarkAggr.R
@@ -60,7 +60,6 @@ BenchmarkAggr = R6Class("BenchmarkAggr",
       private$.independent = assert_flag(independent)
       assert_flag(strip_prefix)
       assert_subset(c(task_id, learner_id), colnames(dt))
-      dt = map_at(dt, c(task_id, learner_id), as.factor)
       assert_factor(unlist(subset(dt, select = task_id)))
       assert_factor(unlist(subset(dt, select = learner_id)))
 

--- a/R/autoplot.BenchmarkAggr.R
+++ b/R/autoplot.BenchmarkAggr.R
@@ -44,10 +44,10 @@
 #' specifying the aspect ratio of the plot, best used with [ggsave()].
 #' @param col (`character(1)`)\cr
 #' For `type = "fn"`, specifies color to fill significant tiles, default is `"red"`.
-#' @param friedman_posthoc (`logical(1)`)\cr
-#' Should a friedman posthoc test be performed for`type = "cd"` and `type = "fn"`?
+#' @param friedman_global (`logical(1)`)\cr
+#' Should a friedman global test be performed for`type = "cd"` and `type = "fn"`?
 #' If `FALSE`, a warning is issued in case the corresponding friedman posthoc test fails instead of an error.
-#' Default is `TRUE`.
+#' Default is `TRUE` (raises an error).
 #' @param ... `ANY` \cr Additional arguments, currently unused.
 #'
 #' @references
@@ -83,7 +83,7 @@
 autoplot.BenchmarkAggr = function(obj, type = c("mean", "box", "fn", "cd"), meas = NULL, # nolint
                                   level = 0.95, p.value = 0.05, minimize = TRUE, # nolint
                                   test = "nem", baseline = NULL, style = 1L,
-                                  ratio = 1/7, col = "red", friedman_posthoc = TRUE, ...) { # nolint
+                                  ratio = 1/7, col = "red", friedman_global = TRUE, ...) { # nolint
 
   # fix no visible binding
   lower = upper = Var1 = Var2 = value = NULL
@@ -93,8 +93,8 @@ autoplot.BenchmarkAggr = function(obj, type = c("mean", "box", "fn", "cd"), meas
   meas = .check_meas(obj, meas)
 
   if (type == "cd") {
-    if (style == 1L) .plot_critdiff_1(obj, meas, p.value, minimize, test, baseline, ratio, friedman_posthoc)
-    else .plot_critdiff_2(obj, meas, p.value, minimize, test, baseline, friedman_posthoc)
+    if (style == 1L) .plot_critdiff_1(obj, meas, p.value, minimize, test, baseline, ratio, friedman_global)
+    else .plot_critdiff_2(obj, meas, p.value, minimize, test, baseline, friedman_global)
   } else if (type == "mean") {
     if (obj$ntasks < 2) {
       stop("At least two tasks required.")
@@ -113,12 +113,12 @@ autoplot.BenchmarkAggr = function(obj, type = c("mean", "box", "fn", "cd"), meas
 
     p = tryCatch(obj$friedman_posthoc(meas, p.value)$p.value,
                  warning = function(w) {
-                   if (friedman_posthoc)
+                   if (friedman_global)
                      stopf("Global Friedman test non-significant (p > %s), try type = 'mean' instead.", p.value) # nolint
                    else
                      warning(sprintf("Global Friedman test non-significant (p > %s), try type = 'mean' instead.", p.value)) # nolint))
                  })
-    if (friedman_posthoc) {
+    if (friedman_global) {
       p = p[rev(seq_len(nrow(p))), ]
       p = t(p)
       p = cbind(expand.grid(rownames(p), colnames(p)), value = as.numeric(p))

--- a/R/autoplot.BenchmarkAggr.R
+++ b/R/autoplot.BenchmarkAggr.R
@@ -47,7 +47,7 @@
 #' @param friedman_global (`logical(1)`)\cr
 #' Should a friedman global test be performed for`type = "cd"` and `type = "fn"`?
 #' If `FALSE`, a warning is issued in case the corresponding friedman posthoc test fails instead of an error.
-#' Default is `TRUE` (raises an error).
+#' Default is `TRUE` (raises an error if global test fails).
 #' @param ... `ANY` \cr Additional arguments, currently unused.
 #'
 #' @references

--- a/R/plots_cd.R
+++ b/R/plots_cd.R
@@ -1,5 +1,5 @@
-.plot_critdiff_1 = function(obj, meas, p.value, minimize, test, baseline, ratio) { # nolint
-  cd = obj$.__enclos_env__$private$.crit_differences(meas, minimize, p.value, baseline, test)
+.plot_critdiff_1 = function(obj, meas, p.value, minimize, test, baseline, ratio, friedman_posthoc) { # nolint
+  cd = obj$.__enclos_env__$private$.crit_differences(meas, minimize, p.value, baseline, test, friedman_posthoc)
 
   # Plot descriptive lines and learner names
   cd$data$yend = -cd$data$yend
@@ -75,7 +75,7 @@
   return(p)
 }
 
-.plot_critdiff_2 = function(obj, meas, p.value, minimize, test, baseline) { # nolint
+.plot_critdiff_2 = function(obj, meas, p.value, minimize, test, baseline, friedman_posthoc) { # nolint
   cd = obj$.__enclos_env__$private$.crit_differences(meas, minimize, p.value, baseline, test)
 
   # Plot descriptive lines and learner names

--- a/R/plots_cd.R
+++ b/R/plots_cd.R
@@ -1,5 +1,5 @@
-.plot_critdiff_1 = function(obj, meas, p.value, minimize, test, baseline, ratio, friedman_posthoc) { # nolint
-  cd = obj$.__enclos_env__$private$.crit_differences(meas, minimize, p.value, baseline, test, friedman_posthoc)
+.plot_critdiff_1 = function(obj, meas, p.value, minimize, test, baseline, ratio, friedman_global) { # nolint
+  cd = obj$.__enclos_env__$private$.crit_differences(meas, minimize, p.value, baseline, test, friedman_global)
 
   # Plot descriptive lines and learner names
   cd$data$yend = -cd$data$yend
@@ -75,8 +75,8 @@
   return(p)
 }
 
-.plot_critdiff_2 = function(obj, meas, p.value, minimize, test, baseline, friedman_posthoc) { # nolint
-  cd = obj$.__enclos_env__$private$.crit_differences(meas, minimize, p.value, baseline, test)
+.plot_critdiff_2 = function(obj, meas, p.value, minimize, test, baseline, friedman_global) { # nolint
+  cd = obj$.__enclos_env__$private$.crit_differences(meas, minimize, p.value, baseline, test, friedman_global)
 
   # Plot descriptive lines and learner names
   p = ggplot(cd$data)

--- a/man/autoplot.BenchmarkAggr.Rd
+++ b/man/autoplot.BenchmarkAggr.Rd
@@ -16,7 +16,7 @@
   style = 1L,
   ratio = 1/7,
   col = "red",
-  friedman_posthoc = TRUE,
+  friedman_global = TRUE,
   ...
 )
 }
@@ -57,10 +57,10 @@ specifying the aspect ratio of the plot, best used with \code{\link[=ggsave]{ggs
 \item{col}{(\code{character(1)})\cr
 For \code{type = "fn"}, specifies color to fill significant tiles, default is \code{"red"}.}
 
-\item{friedman_posthoc}{(\code{logical(1)})\cr
-Should a friedman posthoc test be performed for\code{type = "cd"} and \code{type = "fn"}?
+\item{friedman_global}{(\code{logical(1)})\cr
+Should a friedman global test be performed for\code{type = "cd"} and \code{type = "fn"}?
 If \code{FALSE}, a warning is issued in case the corresponding friedman posthoc test fails instead of an error.
-Default is \code{TRUE}.}
+Default is \code{TRUE} (raises an error).}
 
 \item{...}{\code{ANY} \cr Additional arguments, currently unused.}
 }

--- a/man/autoplot.BenchmarkAggr.Rd
+++ b/man/autoplot.BenchmarkAggr.Rd
@@ -16,6 +16,7 @@
   style = 1L,
   ratio = 1/7,
   col = "red",
+  friedman_posthoc = TRUE,
   ...
 )
 }
@@ -55,6 +56,11 @@ specifying the aspect ratio of the plot, best used with \code{\link[=ggsave]{ggs
 
 \item{col}{(\code{character(1)})\cr
 For \code{type = "fn"}, specifies color to fill significant tiles, default is \code{"red"}.}
+
+\item{friedman_posthoc}{(\code{logical(1)})\cr
+Should a friedman posthoc test be performed for\code{type = "cd"} and \code{type = "fn"}?
+If \code{FALSE}, a warning is issued in case the corresponding friedman posthoc test fails instead of an error.
+Default is \code{TRUE}.}
 
 \item{...}{\code{ANY} \cr Additional arguments, currently unused.}
 }

--- a/tests/testthat/test_BenchmarkAggr.R
+++ b/tests/testthat/test_BenchmarkAggr.R
@@ -65,7 +65,12 @@ test_that("public methods", {
 
   skip_if_not_installed("PMCMRplus")
   expect_error(ba$friedman_posthoc(), "measures")
-  expect_warning(ba$friedman_posthoc(meas = "RMSE"), "Cannot reject")
+  expect_warning(ba$friedman_posthoc(meas = "RMSE"), "Returning overall")
+  expect_equal(
+    class(expect_warning(ba$friedman_posthoc(meas = "RMSE",
+                                            friedman_global = FALSE),
+                        "unreliable")), "PMCMR"
+  )
   expect_silent(ba$friedman_posthoc(p.value = 0.9, meas = "RMSE"))
 })
 

--- a/tests/testthat/test_autoplot_BenchmarkAggr.R
+++ b/tests/testthat/test_autoplot_BenchmarkAggr.R
@@ -46,7 +46,6 @@ test_that("autoplot with BenchmarkAggr from mlr3::benchmark()", {
     lrn("classif.rpart", id = "rpart2")
   )
   bm = benchmark(benchmark_grid(task, learns, rsmp("cv", folds = 3)))
-
   ba = as.BenchmarkAggr(bm)
   expect_warning(expect_true(ggplot2::is.ggplot(autoplot(ba,
     type = "cd",

--- a/tests/testthat/test_autoplot_BenchmarkAggr.R
+++ b/tests/testthat/test_autoplot_BenchmarkAggr.R
@@ -23,10 +23,10 @@ test_that("autoplot.BenchmarkAggr cd", {
   ba = BenchmarkAggr$new(df)
 
   expect_error(is.ggplot(autoplot(ba, type = "fn")))
-  expect_warning(is.ggplot(autoplot(ba, type = "fn", friedman_posthoc = FALSE)))
+  expect_true(is.ggplot(expect_warning(autoplot(ba, type = "fn", friedman_global = FALSE))))
   expect_silent(is.ggplot(autoplot(ba, type = "fn", p.value = 1, test = "bd")))
   expect_error(is.ggplot(autoplot(ba, type = "cd")))
-  expect_warning(is.ggplot(autoplot(ba, type = "cd", friedman_posthoc = FALSE)))
+  expect_true(is.ggplot(expect_warning(autoplot(ba, type = "cd", friedman_global = FALSE))))
   expect_silent(is.ggplot(autoplot(ba, type = "cd", p.value = 1, test = "bd")))
   expect_silent(is.ggplot(autoplot(ba, type = "cd", p.value = 1, test = "bd", style = 2)))
 })
@@ -45,6 +45,8 @@ test_that("autoplot with BenchmarkAggr from mlr3::benchmark()", {
   learns = lrns(c("classif.featureless", "classif.rpart", "classif.ranger"))
   bm = benchmark(benchmark_grid(task, learns, rsmp("cv", folds = 3)))
   ba = BenchmarkAggr$new(bm$aggregate())
+  expect_true(ggplot2::is.ggplot(autoplot(ba, type = "cd")))
 
+  ba = as.BenchmarkAggr(bm)
   expect_true(ggplot2::is.ggplot(autoplot(ba, type = "cd")))
 })

--- a/tests/testthat/test_autoplot_BenchmarkAggr.R
+++ b/tests/testthat/test_autoplot_BenchmarkAggr.R
@@ -48,7 +48,9 @@ test_that("autoplot with BenchmarkAggr from mlr3::benchmark()", {
   bm = benchmark(benchmark_grid(task, learns, rsmp("cv", folds = 3)))
 
   ba = as.BenchmarkAggr(bm)
-  expect_true(ggplot2::is.ggplot(autoplot(ba, type = "cd")))
-
+  expect_warning(expect_true(ggplot2::is.ggplot(autoplot(ba,
+    type = "cd",
+    friedman_global = FALSE
+  ))))
   expect_true(ggplot2::is.ggplot(autoplot(ba, type = "cd", p.value = 0.2)))
 })

--- a/tests/testthat/test_autoplot_BenchmarkAggr.R
+++ b/tests/testthat/test_autoplot_BenchmarkAggr.R
@@ -23,8 +23,10 @@ test_that("autoplot.BenchmarkAggr cd", {
   ba = BenchmarkAggr$new(df)
 
   expect_error(is.ggplot(autoplot(ba, type = "fn")))
+  expect_warning(is.ggplot(autoplot(ba, type = "fn", friedman_posthoc = FALSE)))
   expect_silent(is.ggplot(autoplot(ba, type = "fn", p.value = 1, test = "bd")))
   expect_error(is.ggplot(autoplot(ba, type = "cd")))
+  expect_warning(is.ggplot(autoplot(ba, type = "cd", friedman_posthoc = FALSE)))
   expect_silent(is.ggplot(autoplot(ba, type = "cd", p.value = 1, test = "bd")))
   expect_silent(is.ggplot(autoplot(ba, type = "cd", p.value = 1, test = "bd", style = 2)))
 })


### PR DESCRIPTION
Introduces a new arg `friedman_global` that allows disabling errors if the friedman global test does not pass for critical differences plots.