### PR TITLE
fix: use `%in%` in `BenchmarkAggr$subset()` rather than `==`

### DIFF
--- a/R/BenchmarkAggr.R
+++ b/R/BenchmarkAggr.R
@@ -280,9 +280,9 @@ BenchmarkAggr = R6Class("BenchmarkAggr",
       dt = private$.dt
 
       if (!is.null(task))
-        dt = subset(dt, get(self$col_roles$task_id) == task)
+        dt = subset(dt, get(self$col_roles$task_id) %in% task)
       if (!is.null(learner))
-        dt = dt[get(self$col_roles$learner_id) == learner]
+        dt = dt[get(self$col_roles$learner_id) %in% learner]
 
       dt
     }


### PR DESCRIPTION
I found that `$subset()` threw a warning if `learner` or `task` was a character length greater 1.
While I wasn't able to create a simple regex to reproduce it, I don't see any downside to using `%in%` here though, which appears to work just fine in my case.