### PR TITLE
Fix CD plot warning

### DIFF
--- a/R/plots_cd.R
+++ b/R/plots_cd.R
@@ -27,7 +27,7 @@
                    y = 2, x = mean(cd$data$mean_rank))
 
   # manually build axis
-  p = p + geom_segment(aes(x = 0, xend = max(rank) + 1, y = 0, yend = 0)) +
+  p = p + annotate("segment", x = 0, xend = max(cd$data$rank) + 1, y = 0, yend = 0) +
     geom_text(data = data.frame(x = seq.int(0, max(cd$data$rank) + 1)),
               aes(x = x, label = x, y = 0.7)) +
     geom_segment(data = data.frame(x = seq.int(0, max(cd$data$rank) + 1)),

--- a/tests/testthat/test_autoplot_BenchmarkAggr.R
+++ b/tests/testthat/test_autoplot_BenchmarkAggr.R
@@ -5,12 +5,12 @@ test_that("autoplot.BenchmarkAggr", {
                   RMSE = runif(100, 0, 1:100))
   ba = BenchmarkAggr$new(df)
 
-  expect_true(is.ggplot(autoplot(ba, type = "mean")))
-  expect_true(is.ggplot(autoplot(ba, type = "box")))
+  expect_true(is_ggplot(autoplot(ba, type = "mean")))
+  expect_true(is_ggplot(autoplot(ba, type = "box")))
 
   skip_if_not_installed("PMCMRplus")
-  expect_true(is.ggplot(autoplot(ba, type = "fn")))
-  expect_true(is.ggplot(autoplot(ba, type = "cd")))
+  expect_true(is_ggplot(autoplot(ba, type = "fn")))
+  expect_true(is_ggplot(autoplot(ba, type = "cd")))
 })
 
 test_that("autoplot.BenchmarkAggr cd", {
@@ -22,13 +22,13 @@ test_that("autoplot.BenchmarkAggr cd", {
                   RMSE = runif(5))
   ba = BenchmarkAggr$new(df)
 
-  expect_error(is.ggplot(autoplot(ba, type = "fn")))
-  expect_true(is.ggplot(expect_warning(autoplot(ba, type = "fn", friedman_global = FALSE))))
-  expect_silent(is.ggplot(autoplot(ba, type = "fn", p.value = 1, test = "bd")))
-  expect_error(is.ggplot(autoplot(ba, type = "cd")))
-  expect_true(is.ggplot(expect_warning(autoplot(ba, type = "cd", friedman_global = FALSE))))
-  expect_silent(is.ggplot(autoplot(ba, type = "cd", p.value = 1, test = "bd")))
-  expect_silent(is.ggplot(autoplot(ba, type = "cd", p.value = 1, test = "bd", style = 2)))
+  expect_error(is_ggplot(autoplot(ba, type = "fn")))
+  expect_true(is_ggplot(expect_warning(autoplot(ba, type = "fn", friedman_global = FALSE))))
+  expect_silent(is_ggplot(autoplot(ba, type = "fn", p.value = 1, test = "bd")))
+  expect_error(is_ggplot(autoplot(ba, type = "cd")))
+  expect_true(is_ggplot(expect_warning(autoplot(ba, type = "cd", friedman_global = FALSE))))
+  expect_silent(is_ggplot(autoplot(ba, type = "cd", p.value = 1, test = "bd")))
+  expect_silent(is_ggplot(autoplot(ba, type = "cd", p.value = 1, test = "bd", style = 2)))
 })
 
 test_that("autoplot with BenchmarkAggr from mlr3::benchmark()", {
@@ -47,9 +47,9 @@ test_that("autoplot with BenchmarkAggr from mlr3::benchmark()", {
   )
   bm = benchmark(benchmark_grid(task, learns, rsmp("cv", folds = 3)))
   ba = as_benchmark_aggr(bm)
-  expect_warning(expect_true(ggplot2::is.ggplot(autoplot(ba,
+  expect_warning(expect_true(ggplot2::is_ggplot(autoplot(ba,
     type = "cd",
     friedman_global = FALSE
   ))))
-  expect_true(ggplot2::is.ggplot(autoplot(ba, type = "cd", p.value = 0.2)))
+  expect_true(ggplot2::is_ggplot(autoplot(ba, type = "cd", p.value = 0.2)))
 })


### PR DESCRIPTION
Closes #45.

I also switched the deprecated `is.ggplot()` with the alternative `is_ggplot()` ggplot2 messages about when running tests interactively.

I think it might also be a good idea to maybe refactor tests a little, at least to use `expect_s3_class(class = "ggplot2")` rather than `expect_true(is_ggplot(...))` but that's another issue/PR.