### PR TITLE
test: replace pima task with sonar

### DIFF
--- a/R/BenchmarkAggr.R
+++ b/R/BenchmarkAggr.R
@@ -23,7 +23,7 @@
 #'
 #' if (requireNamespaces(c("mlr3", "rpart"))) {
 #'   library(mlr3)
-#'   task = tsks(c("pima", "spam"))
+#'   task = tsks(c("sonar", "spam"))
 #'   learns = lrns(c("classif.featureless", "classif.rpart"))
 #'   bm = benchmark(benchmark_grid(task, learns, rsmp("cv", folds = 2)))
 #'
@@ -417,7 +417,7 @@ BenchmarkAggr = R6Class("BenchmarkAggr",
 #'
 #' if (requireNamespaces(c("mlr3", "rpart"))) {
 #'   library(mlr3)
-#'   task = tsks(c("pima", "spam"))
+#'   task = tsks(c("sonar", "spam"))
 #'   learns = lrns(c("classif.featureless", "classif.rpart"))
 #'   bm = benchmark(benchmark_grid(task, learns, rsmp("cv", folds = 2)))
 #'
@@ -477,7 +477,7 @@ as_benchmark_aggr.BenchmarkResult = function(obj, task_id = "task_id", learner_i
 #'
 #' if (requireNamespaces(c("mlr3", "rpart"))) {
 #'   library(mlr3)
-#'   task = tsks(c("pima", "spam"))
+#'   task = tsks(c("sonar", "spam"))
 #'   learns = lrns(c("classif.featureless", "classif.rpart"))
 #'   bm = benchmark(benchmark_grid(task, learns, rsmp("cv", folds = 2)))
 #'

--- a/man/BenchmarkAggr.Rd
+++ b/man/BenchmarkAggr.Rd
@@ -26,7 +26,7 @@ as_benchmark_aggr(df, task_id = "tasks", learner_id = "learners")
 
 if (requireNamespaces(c("mlr3", "rpart"))) {
   library(mlr3)
-  task = tsks(c("pima", "spam"))
+  task = tsks(c("sonar", "spam"))
   learns = lrns(c("classif.featureless", "classif.rpart"))
   bm = benchmark(benchmark_grid(task, learns, rsmp("cv", folds = 2)))
 

--- a/man/as.BenchmarkAggr.Rd
+++ b/man/as.BenchmarkAggr.Rd
@@ -37,7 +37,7 @@ as_benchmark_aggr(df, task_id = "tasks", learner_id = "learners")
 
 if (requireNamespaces(c("mlr3", "rpart"))) {
   library(mlr3)
-  task = tsks(c("pima", "spam"))
+  task = tsks(c("sonar", "spam"))
   learns = lrns(c("classif.featureless", "classif.rpart"))
   bm = benchmark(benchmark_grid(task, learns, rsmp("cv", folds = 2)))
 

--- a/man/as_benchmark_aggr.Rd
+++ b/man/as_benchmark_aggr.Rd
@@ -35,7 +35,7 @@ as_benchmark_aggr(df, task_id = "tasks", learner_id = "learners")
 
 if (requireNamespaces(c("mlr3", "rpart"))) {
   library(mlr3)
-  task = tsks(c("pima", "spam"))
+  task = tsks(c("sonar", "spam"))
   learns = lrns(c("classif.featureless", "classif.rpart"))
   bm = benchmark(benchmark_grid(task, learns, rsmp("cv", folds = 2)))
 

--- a/tests/testthat/test_BenchmarkAggr.R
+++ b/tests/testthat/test_BenchmarkAggr.R
@@ -96,7 +96,7 @@ test_that("mlr3 coercions", {
   skip_if_not_installed("rpart")
 
   library(mlr3)
-  task = tsks(c("pima", "spam"))
+  task = tsks(c("sonar", "spam"))
   learns = lrns(c("classif.featureless", "classif.rpart"))
   bm = benchmark(benchmark_grid(task, learns, rsmp("holdout")))
   expect_equal(class(as_benchmark_aggr(bm))[1], "BenchmarkAggr")


### PR DESCRIPTION
## Why

The `pima` task is being removed from mlr3 because the `PimaIndiansDiabetes2` dataset was removed from the mlbench package. This repo used `tsk("pima")` in documentation examples and one test.

## What

Replaced `tsks(c("pima", "spam"))` with `tsks(c("sonar", "spam"))` in:

- `R/BenchmarkAggr.R` (three roxygen examples)
- `man/BenchmarkAggr.Rd`, `man/as.BenchmarkAggr.Rd`, `man/as_benchmark_aggr.Rd` (generated docs, edited directly)
- `tests/testthat/test_BenchmarkAggr.R`

`sonar` is a binary classification task with no missing values, kept distinct from the `spam` task already used alongside it in the benchmark grid, so task counts and distinctness assertions remain valid. No pima-specific feature/column/target assertions existed.

## Tests

`devtools::test(filter = 'BenchmarkAggr')`: FAIL 0 | PASS 35. The pima-touched test now runs on `sonar` + `spam` and passes. Remaining SKIPs (PMCMRplus not installed) and one ggplot2 deprecation warning are pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)